### PR TITLE
Updated lock.file repo to CRAN closes #20

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       }
     ]
   },

--- a/shiny-fieldwork.Rproj
+++ b/shiny-fieldwork.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 82f7477a-b9db-4eb7-a851-abcae11903da
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
By default renv switches to the package repo to positmanager, which is currently being blocked by IS&T. Updated the lock.file to use CRAN as it's main package repo